### PR TITLE
Disable parallel

### DIFF
--- a/src/box.php
+++ b/src/box.php
@@ -619,17 +619,21 @@ return new class implements DiagnosticsPluginInterface {
         $configFile = $environment->getUniqueTempFile($this, 'box.json');
         file_put_contents($configFile, $json);
 
+        $arguments = [
+            'compile',
+            '--config',
+            $configFile,
+            '-d',
+            $environment->getProjectConfiguration()->getProjectRootPath()
+        ];
+        if (1 === $environment->getAvailableThreads()) {
+            $arguments[] = '--no-parallel';
+        }
         yield $environment
             ->getTaskFactory()
             ->buildRunPhar(
                 'box',
-                [
-                    'compile',
-                    '--config',
-                    $configFile,
-                    '-d',
-                    $environment->getProjectConfiguration()->getProjectRootPath()
-                ]
+                $arguments
             )
             ->withWorkingDirectory($environment->getProjectConfiguration()->getProjectRootPath())
             ->withOutputTransformer($this->createOutputTransformer($contents))

--- a/src/box.php
+++ b/src/box.php
@@ -67,6 +67,14 @@ return new class implements DiagnosticsPluginInterface {
 
     public function describeConfiguration(PluginConfigurationBuilderInterface $configOptionsBuilder): void
     {
+        $configOptionsBuilder
+            ->describeStringListOption(
+                'custom_flags',
+                'Any custom flags to pass. For valid flags refer to the phpcs documentation.',
+            )
+            ->isRequired()
+            ->withDefaultValue([]);
+
         // See https://github.com/box-project/box/blob/master/doc/configuration.md
 
         // https://github.com/box-project/box/blob/master/doc/configuration.md#signing-algorithm-algorithm
@@ -629,6 +637,12 @@ return new class implements DiagnosticsPluginInterface {
         if (1 === $environment->getAvailableThreads()) {
             $arguments[] = '--no-parallel';
         }
+        if ($config->has('custom_flags')) {
+            foreach ($config->getStringList('custom_flags') as $value) {
+                $arguments[] = $value;
+            }
+        }
+
         yield $environment
             ->getTaskFactory()
             ->buildRunPhar(


### PR DESCRIPTION
When we pass `-j1` to phpcq, box should not spawn amp processes but remain single threaded.